### PR TITLE
feat: Add missing ")" in description string for "tmnxSubInfoQos"

### DIFF
--- a/Mibs/Mib/T/TIMETRA-SUBSCRIBER-MGMT-MIB.MIB
+++ b/Mibs/Mib/T/TIMETRA-SUBSCRIBER-MGMT-MIB.MIB
@@ -5170,7 +5170,7 @@ tmnxSubInfoQos                   OBJECT-TYPE
     DESCRIPTION
         "The value of tmnxSubInfoQos indicates the Quality of Service model
          associated with this subscriber. It is determined by the MDA (Media
-         Dependent Adapter) and/or IOM (I/O Module of the subscriber hosts."
+         Dependent Adapter) and/or IOM (I/O Module) of the subscriber hosts."
     ::= { tmnxSubscriberInfoEntry 12 }
 
 tmnxSubInfoShortId               OBJECT-TYPE


### PR DESCRIPTION
This fix is related to SAT-59653 and is needed due to a bug in the SNMP parser that causes it to require every opening parentheses to have a corresponding closing parentheses anywhere in the file, including in the middle of strings.